### PR TITLE
Fix/Glide-Error

### DIFF
--- a/app/src/main/java/com/example/sharingbookshelf/Fragments/MyBookshelfFragment.java
+++ b/app/src/main/java/com/example/sharingbookshelf/Fragments/MyBookshelfFragment.java
@@ -17,6 +17,7 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import com.bumptech.glide.Glide;
+import com.bumptech.glide.RequestManager;
 import com.example.sharingbookshelf.Activities.BarcodeActivity;
 import com.example.sharingbookshelf.Activities.BookInfoPopupActivity;
 import com.example.sharingbookshelf.Activities.MainActivity;
@@ -47,11 +48,12 @@ public class MyBookshelfFragment extends Fragment {
     private CircleImageView civ_profile;
     private TextView tv_nickname;
     private RetrofitServiceApi retrofitServiceApi;
+    public RequestManager mGlideRequestManager;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-
+        mGlideRequestManager = Glide.with(this);
     }
 
     @Override
@@ -164,7 +166,7 @@ public class MyBookshelfFragment extends Fragment {
                 String profileImg = result.getProfileImg();
                 tv_nickname.setText(nickname);
                 if (profileImg != null) {
-                    Glide.with(getActivity()).load(profileImg).into(civ_profile);
+                    mGlideRequestManager.load(profileImg).into(civ_profile);
                 }
             }
 


### PR DESCRIPTION
- Glide 라이브러리 사용 중 런타임 에러 해결
`
E/AndroidRuntime: FATAL EXCEPTION: main
    Process: com.example.sharingbookshelf, PID: 3059
    java.lang.NullPointerException: You cannot start a load on a not yet attached View or a Fragment where getActivity() returns null (which usually occurs when getActivity() is called before the Fragment is attached or after the Fragment is destroyed).
        at com.bumptech.glide.util.Preconditions.checkNotNull(Preconditions.java:29)
        at com.bumptech.glide.Glide.getRetriever(Glide.java:769)
        at com.bumptech.glide.Glide.with(Glide.java:826)
        at com.example.sharingbookshelf.Fragments.MyBookshelfFragment$3.onResponse(MyBookshelfFragment.java:167)
        at retrofit2.DefaultCallAdapterFactory$ExecutorCallbackCall$1.lambda$onResponse$0$DefaultCallAdapterFactory$ExecutorCallbackCall$1(DefaultCallAdapterFactory.java:89)
        at retrofit2.-$$Lambda$DefaultCallAdapterFactory$ExecutorCallbackCall$1$hVGjmafRi6VitDIrPNdoFizVAdk.run(Unknown Source:6)
        at android.os.Handler.handleCallback(Handler.java:938)
        at android.os.Handler.dispatchMessage(Handler.java:99)
        at android.os.Looper.loop(Looper.java:223)
        at android.app.ActivityThread.main(ActivityThread.java:7656)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:592)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:947)
`

- 참고 레퍼런스 : [[Android] Glide Library 사용시 참고 사항](https://gogorchg.tistory.com/entry/Android-Glide-Library-%EC%82%AC%EC%9A%A9%EC%8B%9C-%EC%B0%B8%EA%B3%A0-%EC%82%AC%ED%95%AD)
